### PR TITLE
Add BGPT MCP (scientific paper search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of awesome MCP servers, tools, and resources for the Model Contex
 - https://github.com/microsoft/playwright-mcp
 
 ### MCP Servers
+- https://github.com/connerlambden/bgpt-mcp
 - https://github.com/jaw9c/awesome-remote-mcp-servers
 - https://github.com/Azure-Samples/remote-mcp-functions
 - https://github.com/stuzero/pg-mcp-server


### PR DESCRIPTION
## Summary

Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) to the MCP Servers list.

BGPT MCP enables searching scientific papers and retrieving structured experimental data extracted from full-text studies. Each result returns 25+ fields including methods, results, sample sizes, limitations, and quality scores.

**GitHub**: https://github.com/connerlambden/bgpt-mcp
**Website**: https://bgpt.pro/mcp